### PR TITLE
Remove deprecated cask URL verification

### DIFF
--- a/Casks/whatcable.rb
+++ b/Casks/whatcable.rb
@@ -2,8 +2,7 @@ cask "whatcable" do
   version "1.4.0"
   sha256 "e397334f2410cf0259b014826780f73cc22f79c40719757a5fcbdb026c4b5527"
 
-  url "https://github.com/darrylmorley/whatcable/releases/download/v#{version}/WhatCable.zip",
-      verified: "github.com/darrylmorley/whatcable/"
+  url "https://github.com/darrylmorley/whatcable/releases/download/v#{version}/WhatCable.zip"
   name "WhatCable"
   desc "Menu bar app for USB-C cable diagnostics"
   homepage "https://github.com/darrylmorley/whatcable"


### PR DESCRIPTION
In order to remove the deprecated cask verification warning, this commit removes the verified URL option and relies on Homebrew's default URL verification behavior.\n\nThis parameter was removed by Homebrew/brew#23280 and is listed in the Homebrew 6.0.13 release notes:\nhttps://github.com/Homebrew/brew/releases/tag/6.0.13\n\nCloses #8